### PR TITLE
Moved use strict from makefile to js src for gulp.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ $(I18N_JS): $(I18N_JSON)
 
 
 $(JS_DEV): $(JS_FILES)
-	echo '\n"use strict";\n' | cat $(JS_PREFACE) - $^ > $@
+	cat $(JS_PREFACE) $^ > $@
 
 $(JS_MIN): $(JS_DEV)
 	curl -X POST -s --data-urlencode "input@$^" http://javascript-minifier.com/raw \

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -1,3 +1,5 @@
+"use strict";
+
 if (!String.prototype.trim) {
 	String.prototype.trim = function () {
 		return this.replace(/^\s+|\s+$/g, '');


### PR DESCRIPTION
Use strict was being written directly to the compiled js by the
Makefile but not by the gulpfile, triggering a Chrome bug if you built
with gulp.